### PR TITLE
fix добавлено сообщение-заглушка для preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "echo '⚠️  Preview not available for library mode'",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "lint": "eslint .",


### PR DESCRIPTION
Команда `npm run preview` не имеет смысла для библиотеки, т.к. в каталоге `dist` отсутствуют html файлы для отображения

https://github.com/nii-energomash/metrology-formatting/issues/2