### PR TITLE
fix: починен CJS-вход, браузерная сборка вынесена в iife

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Build
-        run: npm run build
+      # test:dist собирает пакет через pretest:dist и сразу проверяет точки
+      # входа собранного dist: publint такие дефекты не ловит, а юнит-тесты
+      # гоняют src и до dist не доходят.
+      - name: Build and check package entry points
+        run: npm run test:dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,8 +63,11 @@ jobs:
           tag: ${{ github.ref_name }}
           prerelease: ${{ github.event.release.prerelease }}
 
-      - name: Build
-        run: npm run build
+      # test:dist собирает пакет через pretest:dist и сразу проверяет точки входа
+      # собранного dist: publint такие дефекты не ловит, а юнит-тесты гоняют src.
+      # Публикуется тот же dist, что и проверен.
+      - name: Сборка и проверка точек входа
+        run: npm run test:dist
 
       # Встроенный токен вместо PAT: он не истекает, не требует ручного
       # обновления и ограничен этим репозиторием. Права даёт блок permissions.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ console.log(FormattingUtility.toPercentageString(65.432)) // "65,4%"
 console.log(FormattingUtility.toPercentageString(0.03)) // "0,0%" (правило < 0.05%)
 ```
 
+## Подключение в браузере без сборщика
+
+В пакете есть отдельная браузерная сборка `dist/index.iife.js`. Её достаточно
+скопировать в статику проекта и подключить тегом — библиотека объявляет глобаль
+`metrologyFormatting`:
+
+```html
+<script src="/vendor/metrology-formatting.js"></script>
+<script>
+  console.log(metrologyFormatting.FormattingUtility.toStandardFormString(4520))
+</script>
+```
+
+Проектам со сборщиком этот файл не нужен: `import` и `require` берут ESM- и
+CJS-сборки сами.
+
 ## API
 
 ### toStandardFormString(value: number): string

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default defineConfig([
 
   {
     ...pluginVitest.configs.recommended,
-    files: ['tests/**/*.test.js'],
+    files: ['tests/**/*.test.js', 'tests-dist/**/*.test.js'],
   },
 
   eslintConfigPrettier,

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
-    }
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./browser": "./dist/index.iife.js"
   },
   "files": [
     "dist"
@@ -39,6 +40,8 @@
     "build": "vite build",
     "postbuild": "npm run lint:publish",
     "test": "vitest run",
+    "pretest:dist": "npm run build",
+    "test:dist": "vitest run --config vitest.dist.config.js",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",

--- a/tests-dist/package-entrypoints.test.js
+++ b/tests-dist/package-entrypoints.test.js
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { createContext, runInContext } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+
+// Пакет резолвится по имени, а не по путям в dist: так проверяется сама карта
+// exports вместе с расширениями файлов, а не только факт их существования.
+const require = createRequire(import.meta.url)
+const packageName = '@nii-energomash/metrology-formatting'
+
+describe('точки входа собранного пакета', () => {
+  // createRequire обращается к загрузчику Node в обход конвейера Vite: только
+  // так видно, что при "type": "module" Node читает файл как ESM или как CJS.
+  it('require отдаёт FormattingUtility', () => {
+    expect(Object.keys(require(packageName))).toContain('FormattingUtility')
+  })
+
+  it('import отдаёт FormattingUtility', async () => {
+    expect(Object.keys(await import(packageName))).toContain(
+      'FormattingUtility'
+    )
+  })
+
+  // Контекст vm пустой — без module, exports и define, то есть ровно те условия,
+  // в которых бандл оказывается на странице при подключении тегом script.
+  it('браузерная сборка объявляет глобаль metrologyFormatting', () => {
+    const source = readFileSync(
+      require.resolve(`${packageName}/browser`),
+      'utf8'
+    )
+    const context = createContext({})
+    runInContext(source, context)
+
+    expect(context.metrologyFormatting).toHaveProperty('FormattingUtility')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,8 +6,11 @@ export default defineConfig({
     lib: {
       entry: fileURLToPath(new URL('./src/index.js', import.meta.url)),
       name: 'metrologyFormatting',
-      fileName: format => `index.${format}.js`,
-      formats: ['es', 'umd'],
+      // fileName задаётся строкой, чтобы расширение выбирал Vite: при
+      // "type": "module" он даёт .cjs формату cjs и .js остальным.
+      // Функциональная форма возвращает имя целиком и этот подбор обходит.
+      fileName: 'index',
+      formats: ['es', 'cjs', 'iife'],
     },
     sourcemap: true,
     minify: 'terser',

--- a/vitest.dist.config.js
+++ b/vitest.dist.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// Проверка собранного пакета вынесена в отдельный конфиг: этим тестам нужен
+// готовый dist, и в выборку `npm test` (только tests/) они попадать не должны.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests-dist/**/*.test.js'],
+  },
+})


### PR DESCRIPTION
Closes #45

## Проблема

В манифесте `"type": "module"`, а `exports.require` указывал на
`./dist/index.umd.js`. Под `type: module` Node читает `.js` как ESM, UMD-обёртка
не отрабатывает, и `require('@nii-energomash/metrology-formatting')` молча
возвращает пустой объект. Юнит-тесты дефект не видят — гоняют `src`;
`publint --strict` тоже даёт `All good!`.

## Решение

Расширения выходных файлов больше не задаются вручную: `build.lib.fileName`
переведён на строковую форму, и подбор расширения остаётся за Vite — при
`"type": "module"` он сам даёт `.cjs` формату `cjs` и `.js` остальным.
Рассогласовать расширение файла с картой `exports` теперь нечем.

UMD заменён двумя отдельными сборками. Одна обёртка закрывала сразу два
сценария и после починки закрывала бы их плохо: для браузера файл получил бы
расширение `.cjs` и уехал бы на страницу с нераспознанным MIME-типом, а сама
UMD-обёртка объявляет глобаль только если не нашла ни `module.exports`, ни
`define`. Теперь `cjs` обслуживает `require`, а `iife` — подключение тегом
`<script>`: глобаль `metrologyFormatting` объявляется всегда, расширение
остаётся `.js`.

Состав `dist`: `index.js` (ESM), `index.cjs` (CJS), `index.iife.js` (браузер).

## Регрессия

Дефект ловится только фактическим обращением к собранному пакету, поэтому
добавлен прогон против `dist` — `tests-dist/package-entrypoints.test.js` с
отдельным конфигом `vitest.dist.config.js`:

- `require` через `createRequire`, то есть настоящий загрузчик Node в обход
  конвейера Vite;
- `import`;
- исполнение браузерного бандла в пустом контексте `node:vm` — без `module`,
  `exports` и `define`, как на странице.

Пакет во всех трёх случаях резолвится по имени, а не по путям в `dist`, — так
проверяется сама карта `exports`.

Отдельная директория и конфиг нужны, чтобы `npm test` (include `tests/**`) не
подхватывал тесты, требующие предварительной сборки, и не падал на чистом клоне.
В обоих workflow шаг `npm run build` заменён на `npm run test:dist`: сборка идёт
внутри через `pretest:dist`, публикуется тот же `dist`, что и проверен.

## Проверка

- `npm run test:dist` — 3/3, `publint --strict` в `postbuild` — `All good!`
- прямой прогон в обход Vitest:
  `node -e "console.log(Object.keys(require('@nii-energomash/metrology-formatting')))"`
  → `[ 'FormattingUtility' ]`
- негативная проверка: при `exports.require`, направленном на файл без
  CJS-экспортов, тест падает с `expected [] to include 'FormattingUtility'` —
  ровно симптом из issue
- `npm run lint`, `npm run format:check`, `npm test` (75 тестов) — чисто

## После слияния

Меняются имена файлов в публикуемом пакете и добавляется подпуть `./browser`,
поэтому нужен релиз `v2.1.0` — минор, а не патч.