### PR TITLE
refactor: разбор значения переведён с исключений на возврат null

### DIFF
--- a/src/numeric.js
+++ b/src/numeric.js
@@ -1,18 +1,18 @@
 /**
  * Приводит значение к числу, пригодному для форматирования
  * @param {*} value Значение для разбора
- * @returns {Number} Числовое представление значения
- * @throws {Error} Если значение не может быть представлено числом
+ * @returns {Number|null} Числовое представление значения либо null, если значение непригодно
  */
-export function parseNumericOrThrow(value) {
+export function parseNumeric(value) {
   // Глобальный isFinite приводит аргумент к числу, в отличие от Number.isFinite,
   // и потому пропускает числа, записанные строкой, — это поддержанный вход.
-  if (!isFinite(value))
-    throw new Error('Значение не может быть представлено числом')
+  if (!isFinite(value)) return null
 
   const numericValue = parseFloat(value)
 
-  if (isNaN(numericValue)) throw new Error('Значение является NaN')
+  // Проверка не избыточна: '', null и [] проходят isFinite как ноль,
+  // но parseFloat даёт по ним NaN.
+  if (isNaN(numericValue)) return null
 
   return numericValue
 }

--- a/src/percentage.js
+++ b/src/percentage.js
@@ -1,4 +1,4 @@
-import { parseNumericOrThrow } from './numeric'
+import { parseNumeric } from './numeric'
 
 /**
  * Вывод процента с точностью до 1 знака после запятой
@@ -6,9 +6,9 @@ import { parseNumericOrThrow } from './numeric'
  * @returns {String} Строка в процентах, либо пустая строка для непригодного значения
  */
 export function toPercentageString(value) {
-  try {
-    return parseNumericOrThrow(value).toFixed(1)
-  } catch {
-    return ''
-  }
+  const numericValue = parseNumeric(value)
+
+  if (numericValue === null) return ''
+
+  return numericValue.toFixed(1)
 }

--- a/src/standardForm.js
+++ b/src/standardForm.js
@@ -1,4 +1,4 @@
-import { parseNumericOrThrow, roundTo } from './numeric'
+import { parseNumeric, roundTo } from './numeric'
 
 // Знак снимается один раз, в toStandardFormParts, и ниже его не существует:
 // форму представления определяет только величина. Поэтому toExponentialParts
@@ -100,16 +100,17 @@ function toStandardFormObjectOrThrow(numericValue) {
  * @returns {Object} Стандартное представление числа { sign, mantissa, base, exponent }, содержащее строки
  */
 export function toStandardFormObject(value) {
-  try {
-    return toStandardFormObjectOrThrow(parseNumericOrThrow(value))
-  } catch {
+  const numericValue = parseNumeric(value)
+
+  if (numericValue === null)
     return {
       sign: '',
       mantissa: '',
       base: '',
       exponent: '',
     }
-  }
+
+  return toStandardFormObjectOrThrow(numericValue)
 }
 
 /**


### PR DESCRIPTION
## Проблема

`toStandardFormObject` и `toPercentageString` перехватывали исключение без разбора:

```js
try {
  return toStandardFormObjectOrThrow(parseNumericOrThrow(value))
} catch {
  return { sign: '', mantissa: '', base: '', exponent: '' }
}
```

Непригодный вход и дефект самой библиотеки давали один и тот же ответ. Дефект
не проявлялся у потребителя ничем: ни падением, ни записью в лог — только пустое
поле, неотличимое от штатного ответа на мусор. Диагноз в таком случае ставится
данным, а не библиотеке, и сообщения о баге не появляется никогда.

## Решение

Исключение перестаёт быть механизмом проверки входа: непригодное значение —
не исключительная ситуация, а половина сценариев использования. `try/catch` убран,
`parseNumericOrThrow` заменена на `parseNumeric`, возвращающую `Number` либо `null`.

```js
export function toStandardFormObject(value) {
  const numericValue = parseNumeric(value)

  if (numericValue === null)
    return { sign: '', mantissa: '', base: '', exponent: '' }

  return toStandardFormObjectOrThrow(numericValue)
}
```

Перехвата нет — значит любое исключение из `toStandardFormObjectOrThrow` доходит
до потребителя само, со стеком. Кода стало меньше, а не больше.

Направление, записанное в теле issue, — завести собственный тип ошибки и ловить
только его — отклонено; разбор в
[комментарии к issue](https://github.com/nii-energomash/metrology-formatting/issues/53#issuecomment-5310257550).
Коротко: в момент падения тип ошибки ничего не даёт (стек уже назвал файл и строку),
а против главной опасности — тихо неверного числа — не помогает вовсе, при этом
требует экспорта типа в публичный API.

`null`, а не `NaN`: забытая при будущей правке проверка на `null` даёт `TypeError`
с файлом и строкой, а на `NaN` — строку `"NaN"` в выводе у потребителя, то есть ровно
тот тихо неверный результат, от которого и защищаемся. Кроме того, `Number|null`
выразим в JSDoc, тогда как `NaN` в системе типов от обычного числа неотличим.

## Изменение поведения

На пригодном и на непригодном входе поведение прежнее — существующие 87 тестов
проходят без правок. Меняется поведение только на дефекте реализации: вместо пустого
объекта потребитель получает исключение. Размен осознанный — пустое поле в ячейке
живёт годами, потому что о нём никто не сообщает, а падение чинится в тот же день.

Публичный API не затронут: `parseNumericOrThrow` наружу никогда не экспортировалась,
`src/index.js` и `FormattingUtility` не менялись.

Бросок «Невозможно представить ноль в стандартном виде» оставлен как есть: из публичного
пути он недостижим — ноль отсекается раньше, в `toStandardFormParts`. Это защита
инварианта для будущих правок, и падать со стеком — её работа.

## Вне объёма

- Тесты не правились: внешнее поведение не изменилось, а `parseNumeric` наружу
  не экспортируется.
- README не правился: описание пустых полей на непригодном входе остаётся верным.
- Переименование `toStandardFormObjectOrThrow` — суффикс потерял парную
  `parseNumericOrThrow` — отдельный вопрос.

## Проверка

`npm run lint`, `npm test` (87 тестов), `npm run test:dist` (сборка, publint, точки
входа собранного пакета) — зелёные.

Отдельно проверено то, ради чего делалась правка. При временно переименованном поле
`mantissa` в `toPlainParts` прогон падает так:

```
TypeError: Cannot read properties of undefined (reading 'toFixed')
 ❯ toStandardFormObjectOrThrow src/standardForm.js:91:24
 ❯ Object.toStandardFormObject src/standardForm.js:113:10
```

До правки тот же дефект давал молчаливый пустой объект.

Closes #53