### PR TITLE
feat: правило округления вынесено в опцию roundingMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ CJS-сборки сами.
 
 ## API
 
-### toStandardFormString(value: number): string
+Все три функции принимают вторым необязательным аргументом объект настроек:
+на сегодня в нём одно поле — [`roundingMode`](#правило-округления).
+
+### toStandardFormString(value: number, options?: { roundingMode?: string }): string
 
 Функция принимает числовое значение и возвращает его строковое представление по правилам метрологии:
 
@@ -114,7 +117,7 @@ CJS-сборки сами.
 
 Пример: 0.0282 → "2.82×10^-2"
 
-### toStandardFormObject(value: number): StandardFormObject
+### toStandardFormObject(value: number, options?: { roundingMode?: string }): StandardFormObject
 
 Функция принимает числовое значение и обрабатывает его по тем же правилам, что и toStandardFormString(). Но возвращает объект вида:
 
@@ -130,7 +133,7 @@ CJS-сборки сами.
 Все четыре поля — строки. Когда представление обходится без порядка, `base` и `exponent`
 пусты; для неположительного знака `sign` пуст. На непригодном входе пусты все четыре поля.
 
-### toPercentageString(value: number): string
+### toPercentageString(value: number, options?: { roundingMode?: string }): string
 
 Функция принимает числовое значение и обрабатывает его по правилам метрологии для процентов:
 
@@ -147,6 +150,40 @@ CJS-сборки сами.
 65.432 → "65.4"
 
 0.03 → "0.0"
+
+### Правило округления
+
+Единственного «правильного» правила округления у библиотеки нет: соответствия
+какому-либо стандарту она не заявляет. Поэтому правило задаётся вызывающим —
+полем `roundingMode` в объекте настроек:
+
+```js
+toPercentageString(2.25) // "2.3" — правило по умолчанию
+toPercentageString(2.25, { roundingMode: 'halfEven' }) // "2.2" — банковское
+toPercentageString(2.29, { roundingMode: 'trunc' }) // "2.2" — усечение
+```
+
+Допустимые значения — те же, что у
+[`Intl.NumberFormat`](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode):
+`ceil`, `floor`, `expand`, `trunc`, `halfCeil`, `halfFloor`, `halfExpand`,
+`halfTrunc`, `halfEven`. Свой список библиотека не заводит и округление
+выполняет тем же `Intl.NumberFormat`, поэтому неизвестное значение приводит
+к `RangeError` от самой платформы.
+
+По умолчанию действует `halfExpand` — округление от нуля, в том числе ровно
+на середине интервала: `2.25 → "2.3"`, `-2.25 → "-2.3"`.
+
+Правила `ceil`, `floor`, `halfCeil` и `halfFloor` отсчитывают направление
+от знака, а не от нуля, и на отрицательных значениях расходятся с `expand`
+и `trunc`: `-2.113` даёт `"-2.12"` при `floor` и `"-2.11"` при `trunc`.
+
+В стандартной форме правило влияет не только на цифры, но и на выбор формы
+записи — порог сравнивается с уже округлённым значением:
+
+```js
+toStandardFormString(0.0999) // "0.100"
+toStandardFormString(0.0999, { roundingMode: 'trunc' }) // "9.99×10^-2"
+```
 
 ## Примеры работы
 

--- a/src/numeric.js
+++ b/src/numeric.js
@@ -36,38 +36,93 @@ export function splitExponential(value) {
   return { mantissa: Number(mantissa), exponent: Number(exponent) }
 }
 
+/** Правило округления, применяемое, когда вызывающий не назвал своё */
+const DEFAULT_ROUNDING_MODE = 'halfExpand'
+
+// Форматтеры кэшируются, потому что их построение на порядок дороже самого
+// форматирования: без кэша двести тысяч округлений занимают 6.7 с вместо 0.15 с.
+// Расти кэшу некуда — decimalPlaces задаётся только внутри библиотеки и лежит
+// в диапазоне 0…3, а правил округления девять.
+const formatterCache = new Map()
+
 /**
- * Сдвигает десятичный порядок числа на указанное количество разрядов
- * @param {Number} value Сдвигаемое число
- * @param {Number} places Количество разрядов, отрицательное сдвигает вправо
- * @returns {Number} Число со сдвинутым порядком
+ * Отдаёт форматтер, округляющий до указанной точности по указанному правилу
+ * @param {Number} decimalPlaces Количество знаков после запятой
+ * @param {String} roundingMode Правило округления
+ * @returns {Intl.NumberFormat} Форматтер
+ * @throws {RangeError} Если правило округления неизвестно
  */
-function shiftExponent(value, places) {
-  // Сдвиг порядка выполняется правкой текста записи, а не умножением на
-  // степень десяти: новых цифр это не создаёт, а обратный разбор даёт
-  // ближайшее к результату число, поэтому "2.15e1" превращается в ровно 21.5.
-  // Умножение же вносит погрешность: 2.15 * 10 даёт 21.499999999999996,
-  // и середина интервала округляется вниз вопреки правилу.
-  //
-  // Мантисса подставляется числом: она лежит в [1, 10), и её строковое
-  // представление экспоненциальной формы не имеет.
-  const { mantissa, exponent } = splitExponential(value)
-  return Number(`${mantissa}e${exponent + places}`)
+function getFormatter(decimalPlaces, roundingMode) {
+  const key = `${roundingMode}:${decimalPlaces}`
+  const cached = formatterCache.get(key)
+
+  if (cached) return cached
+
+  // Локаль и отключение группировки — требование к коду, а не оформление:
+  // результат разбирается обратно через Number, и тому нужны ASCII-цифры,
+  // точка в роли разделителя и отсутствие разделителей разрядов.
+  const formatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+    roundingMode,
+    useGrouping: false,
+  })
+
+  formatterCache.set(key, formatter)
+
+  return formatter
+}
+
+// Правила, отсчитывающие направление от знака, а не от нуля. Для величины
+// такое правило переписывается на равносильное ему беззнаковое, и переписать
+// его надо, потому что в отрыве от знака оно означает уже не то: floor
+// на отрицательном уводит от нуля, то есть по величине это expand.
+// Таблица — GetUnsignedRoundingMode из ECMA-402; правила, не зависящие от
+// знака, в ней отсутствуют и остаются собой.
+const UNSIGNED_ROUNDING_MODES = {
+  ceil: { positive: 'expand', negative: 'trunc' },
+  floor: { positive: 'trunc', negative: 'expand' },
+  halfCeil: { positive: 'halfExpand', negative: 'halfTrunc' },
+  halfFloor: { positive: 'halfTrunc', negative: 'halfExpand' },
 }
 
 /**
- * Округляет число до указанного количества знаков после запятой.
- * Ровно на середине интервала округление идёт от нуля.
+ * Переписывает правило округления на равносильное ему правило для величины числа
+ * @param {String} [roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
+ * @param {Boolean} isNegative Признак отрицательного числа
+ * @returns {String|undefined} Правило, дающее на величине тот же результат
+ */
+export function toUnsignedRoundingMode(roundingMode, isNegative) {
+  // Неизвестное правило проходит насквозь: сообщить о нём — дело Intl,
+  // свой список значений тогда пришлось бы держать в актуальном состоянии.
+  const equivalent = UNSIGNED_ROUNDING_MODES[roundingMode]
+
+  if (!equivalent) return roundingMode
+
+  return isNegative ? equivalent.negative : equivalent.positive
+}
+
+/**
+ * Округляет число до указанного количества знаков после запятой
  * @param {Number} value Округляемое число
  * @param {Number} decimalPlaces Количество знаков после запятой
+ * @param {String} [roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
  * @returns {Number} Округлённое число
+ * @throws {RangeError} Если правило округления неизвестно
  */
-export function roundTo(value, decimalPlaces) {
-  // Знак снимается до округления и возвращается после: Math.round гонит
-  // середину к плюс бесконечности, и на отрицательных правило без этого
-  // отличалось бы от правила на положительных.
-  const sign = value < 0 ? -1 : 1
-  const shifted = shiftExponent(Math.abs(value), decimalPlaces)
-
-  return sign * shiftExponent(Math.round(shifted), -decimalPlaces)
+export function roundTo(
+  value,
+  decimalPlaces,
+  roundingMode = DEFAULT_ROUNDING_MODE
+) {
+  // Округление отдано Intl.NumberFormat, а не собрано из Math.round и сдвига
+  // порядка: ECMA-402 предписывает ему округлять кратчайшую десятичную запись
+  // числа (ToIntlMathematicalValue берёт Number::toString), то есть ровно то
+  // десятичное значение, которое написал вызывающий, а не его двоичное
+  // приближение — у 2.675 это "2.675", хотя хранится 2.67499999999999982.
+  // toFixed же округляет двоичное значение и даёт "2.67".
+  //
+  // Знак Intl обрабатывает сам, и снимать его нельзя: ceil и floor по
+  // определению зависят от знака, а не от величины.
+  return Number(getFormatter(decimalPlaces, roundingMode).format(value))
 }

--- a/src/percentage.js
+++ b/src/percentage.js
@@ -3,14 +3,17 @@ import { parseNumeric, roundTo } from './numeric'
 /**
  * Вывод процента с точностью до 1 знака после запятой
  * @param {*} value Значение для форматирования
+ * @param {Object} [options] Настройки форматирования
+ * @param {String} [options.roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
  * @returns {String} Строка в процентах, либо пустая строка для непригодного значения
+ * @throws {RangeError} Если правило округления неизвестно
  */
-export function toPercentageString(value) {
+export function toPercentageString(value, { roundingMode } = {}) {
   const numericValue = parseNumeric(value)
 
   if (numericValue === null) return ''
 
   // Округление выполняет roundTo, toFixed остаётся только дописать знак:
   // сам по себе он округляет двоичное значение, а не десятичное.
-  return roundTo(numericValue, 1).toFixed(1)
+  return roundTo(numericValue, 1, roundingMode).toFixed(1)
 }

--- a/src/standardForm.js
+++ b/src/standardForm.js
@@ -1,18 +1,29 @@
-import { parseNumeric, roundTo, splitExponential } from './numeric'
+import {
+  parseNumeric,
+  roundTo,
+  splitExponential,
+  toUnsignedRoundingMode,
+} from './numeric'
 
 // Знак снимается один раз, в toStandardFormParts, и ниже его не существует:
 // форму представления определяет только величина. Поэтому toExponentialParts
 // и toPlainParts принимают величину, а не число — подача им отрицательного
 // не даст ни исключения, ни верного ответа: знак уедет в мантиссу, и вызывающий
 // припишет к ней второй.
+//
+// Вместе со знаком теряет смысл и правило округления, отсчитанное от знака,
+// поэтому там же оно переписывается на равносильное беззнаковое: ниже
+// по цепочке ходит уже результат toUnsignedRoundingMode, а не то, что назвал
+// вызывающий.
 
 /**
  * Раскладывает величину на мантиссу и десятичный порядок
  * @param {Number} absValue Величина числа, строго больше нуля
+ * @param {String} [unsignedRoundingMode] Правило округления, уже переписанное для величины
  * @returns {Object} Части представления числами
  * @throws {Error} Если величина равна нулю
  */
-function toExponentialParts(absValue) {
+function toExponentialParts(absValue, unsignedRoundingMode) {
   // Разложение нуля молчит: (0).toExponential() даёт "0e+0", то есть нулевую
   // мантиссу вместо величины из [1, 10). Стандартного вида у нуля нет.
   if (absValue === 0)
@@ -23,7 +34,7 @@ function toExponentialParts(absValue) {
   // Округление до двух знаков может дать перенос через разряд: 9.995 -> 10.
   // Мантисса стандартного вида лежит в [1, 10), поэтому перенос уходит
   // в порядок. Результат переноса всегда ровно десять, делить нечего.
-  const roundedMantissa = roundTo(mantissa, 2)
+  const roundedMantissa = roundTo(mantissa, 2, unsignedRoundingMode)
 
   return roundedMantissa < 10
     ? { mantissa: roundedMantissa, decimalPlaces: 2, base: 10, exponent }
@@ -43,60 +54,74 @@ function toPlainParts(absValue, decimalPlaces = 0) {
 /**
  * Выбирает между экспоненциальной и обычной записью по величине числа
  * @param {Number} numericValue Разобранное число, любого знака
+ * @param {String} [unsignedMode] Правило округления, уже переписанное для величины
  * @returns {Object} Части представления числами
  */
-function toStandardFormParts(numericValue) {
+function toStandardFormParts(numericValue, unsignedMode) {
   const absValue = Math.abs(numericValue)
 
   if (absValue === 0) return toPlainParts(absValue, 3)
 
   // Порог проверяется по уже округлённому значению: 0.0999 должно попасть
   // в трёхзначную ветку как 0.100, а не уйти в экспоненциальную запись.
-  const roundedToHundredths = roundTo(absValue, 2)
-  if (roundedToHundredths < 0.1) return toExponentialParts(absValue)
+  const roundedToHundredths = roundTo(absValue, 2, unsignedMode)
+  if (roundedToHundredths < 0.1)
+    return toExponentialParts(absValue, unsignedMode)
 
-  const roundedToThousandths = roundTo(absValue, 3)
+  const roundedToThousandths = roundTo(absValue, 3, unsignedMode)
   if (roundedToThousandths < 1) return toPlainParts(roundedToThousandths, 3)
 
   if (roundedToHundredths < 10) return toPlainParts(roundedToHundredths, 2)
 
-  const roundedToTenths = roundTo(absValue, 1)
+  const roundedToTenths = roundTo(absValue, 1, unsignedMode)
   if (roundedToTenths < 100) return toPlainParts(roundedToTenths, 1)
 
-  const roundedToInteger = roundTo(absValue, 0)
+  const roundedToInteger = roundTo(absValue, 0, unsignedMode)
   if (roundedToInteger < 1000) return toPlainParts(roundedToInteger, 0)
 
   // В экспоненциальную ветку уходит исходная величина, а не округлённая:
   // округление до нужного числа значащих цифр выполняется за один шаг,
   // ступенчатое накапливает смещение — 1004.5 через целое даёт 1.01×10^3.
-  return toExponentialParts(absValue)
+  return toExponentialParts(absValue, unsignedMode)
 }
 
 /**
  * Записывает мантиссу строкой с заданным количеством знаков после запятой
  * @param {Number} mantissa Мантисса числом
  * @param {Number} decimalPlaces Количество знаков после запятой
+ * @param {String} [unsignedMode] Правило округления, уже переписанное для величины
  * @returns {String} Мантисса строкой
  */
-function formatMantissa(mantissa, decimalPlaces) {
+function formatMantissa(mantissa, decimalPlaces, unsignedMode) {
   // Округление выполняет roundTo, toFixed остаётся только дописать знаки:
   // сам по себе он округляет двоичное значение, а не десятичное.
-  return roundTo(mantissa, decimalPlaces).toFixed(decimalPlaces)
+  return roundTo(mantissa, decimalPlaces, unsignedMode).toFixed(decimalPlaces)
 }
 
 /**
  * Собирает представление числа строками
  * @param {Number} numericValue Разобранное число, любого знака
+ * @param {String} [roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
  * @returns {Object} Стандартное представление числа { sign, mantissa, base, exponent }
  * @throws {Error} Если число невозможно представить в стандартном виде
+ * @throws {RangeError} Если правило округления неизвестно
  */
-function toStandardFormObjectOrThrow(numericValue) {
-  const { mantissa, decimalPlaces, base, exponent } =
-    toStandardFormParts(numericValue)
+function toStandardFormObjectOrThrow(numericValue, roundingMode) {
+  const isNegative = numericValue < 0
+  const unsignedMode = toUnsignedRoundingMode(roundingMode, isNegative)
+
+  const { mantissa, decimalPlaces, base, exponent } = toStandardFormParts(
+    numericValue,
+    unsignedMode
+  )
 
   return {
-    sign: numericValue < 0 ? '-' : '',
-    mantissa: formatMantissa(mantissa, mantissa != 0 ? decimalPlaces : 2),
+    sign: isNegative ? '-' : '',
+    mantissa: formatMantissa(
+      mantissa,
+      mantissa != 0 ? decimalPlaces : 2,
+      unsignedMode
+    ),
     base: base === null ? '' : String(base),
     exponent: exponent === null ? '' : String(exponent),
   }
@@ -105,9 +130,12 @@ function toStandardFormObjectOrThrow(numericValue) {
 /**
  * Возвращает объект, содержащий представление числа в стандартном виде или в обычном виде в зависимости от величины числа
  * @param {*} value Значение для форматирования
+ * @param {Object} [options] Настройки форматирования
+ * @param {String} [options.roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
  * @returns {Object} Стандартное представление числа { sign, mantissa, base, exponent }, содержащее строки
+ * @throws {RangeError} Если правило округления неизвестно
  */
-export function toStandardFormObject(value) {
+export function toStandardFormObject(value, { roundingMode } = {}) {
   const numericValue = parseNumeric(value)
 
   if (numericValue === null)
@@ -118,16 +146,22 @@ export function toStandardFormObject(value) {
       exponent: '',
     }
 
-  return toStandardFormObjectOrThrow(numericValue)
+  return toStandardFormObjectOrThrow(numericValue, roundingMode)
 }
 
 /**
  * Возвращает строковое представление числа в стандартном виде или в обычном виде в зависимости от величины числа
  * @param {*} value Значение для форматирования
+ * @param {Object} [options] Настройки форматирования
+ * @param {String} [options.roundingMode] Правило округления, значения те же, что у Intl.NumberFormat
  * @returns {String} Строковое представление числа
+ * @throws {RangeError} Если правило округления неизвестно
  */
-export function toStandardFormString(value) {
-  const { sign, mantissa, base, exponent } = toStandardFormObject(value)
+export function toStandardFormString(value, options) {
+  const { sign, mantissa, base, exponent } = toStandardFormObject(
+    value,
+    options
+  )
 
   if (!mantissa) return ''
 

--- a/tests/FormattingUtility.toPercentageString.test.js
+++ b/tests/FormattingUtility.toPercentageString.test.js
@@ -67,6 +67,65 @@ describe('Передаем корректные значения', () => {
   })
 })
 
+describe('Задаём правило округления', () => {
+  it('Когда опции не переданы, округлять по halfExpand', () => {
+    expect(FormattingUtility.toPercentageString(2.15)).toBe(
+      FormattingUtility.toPercentageString(2.15, {
+        roundingMode: 'halfExpand',
+      })
+    )
+  })
+
+  it('Когда объект опций пуст, округлять по правилу по умолчанию', () => {
+    expect(FormattingUtility.toPercentageString(2.15, {})).toBe('2.2')
+  })
+
+  it('2.25 -> "2.2" по halfEven. Середина уходит к чётной цифре', () => {
+    expect(
+      FormattingUtility.toPercentageString(2.25, { roundingMode: 'halfEven' })
+    ).toBe('2.2')
+  })
+
+  it('2.15 -> "2.2" по halfEven. Середина уходит к чётной цифре вверх', () => {
+    expect(
+      FormattingUtility.toPercentageString(2.15, { roundingMode: 'halfEven' })
+    ).toBe('2.2')
+  })
+
+  it('2.19 -> "2.1" по trunc. Дробная часть отбрасывается', () => {
+    expect(
+      FormattingUtility.toPercentageString(2.19, { roundingMode: 'trunc' })
+    ).toBe('2.1')
+  })
+
+  it('-2.19 -> "-2.1" по trunc. Усечение идёт к нулю независимо от знака', () => {
+    expect(
+      FormattingUtility.toPercentageString(-2.19, { roundingMode: 'trunc' })
+    ).toBe('-2.1')
+  })
+
+  // Правила ceil и floor отсчитывают направление от знака, а не от нуля,
+  // поэтому на отрицательном они расходятся с trunc и expand. Пара проверок
+  // ниже ловит подмену знака величиной.
+  it('-2.11 -> "-2.2" по floor. Направление отсчитывается от знака', () => {
+    expect(
+      FormattingUtility.toPercentageString(-2.11, { roundingMode: 'floor' })
+    ).toBe('-2.2')
+  })
+
+  it('-2.19 -> "-2.1" по ceil. Направление отсчитывается от знака', () => {
+    expect(
+      FormattingUtility.toPercentageString(-2.19, { roundingMode: 'ceil' })
+    ).toBe('-2.1')
+  })
+
+  it('Когда правило неизвестно, бросить RangeError', () => {
+    expect(() =>
+      FormattingUtility.toPercentageString(2.15, { roundingMode: 'halfeven' })
+    ).toThrow(RangeError)
+  })
+})
+
 describe('Округляем середину интервала', () => {
   // Точечная проверка на 2.15 закрывает один случай из четырёхсот: середины,
   // не представимые в двоичной плавающей точке точно, расходятся вразнобой.

--- a/tests/FormattingUtility.toStandardFormObject.test.js
+++ b/tests/FormattingUtility.toStandardFormObject.test.js
@@ -278,3 +278,53 @@ describe('Передаем корректные значения', () => {
     expect(result.exponent).toBe('-4')
   })
 })
+
+describe('Задаём правило округления', () => {
+  it('Когда опции не переданы, округлять по halfExpand', () => {
+    expect(FormattingUtility.toStandardFormObject(9.995)).toEqual(
+      FormattingUtility.toStandardFormObject(9.995, {
+        roundingMode: 'halfExpand',
+      })
+    )
+  })
+
+  it('9.995 -> {"9.99"} по trunc. Переноса через разряд не происходит', () => {
+    const result = FormattingUtility.toStandardFormObject(9.995, {
+      roundingMode: 'trunc',
+    })
+    expect(result.sign).toBe('')
+    expect(result.mantissa).toBe('9.99')
+    expect(result.base).toBe('')
+    expect(result.exponent).toBe('')
+  })
+
+  it('0.00009995 -> {"9.99×10^-5"} по trunc. Переноса нет, порядок не поднимается', () => {
+    const result = FormattingUtility.toStandardFormObject(0.00009995, {
+      roundingMode: 'trunc',
+    })
+    expect(result.sign).toBe('')
+    expect(result.mantissa).toBe('9.99')
+    expect(result.base).toBe('10')
+    expect(result.exponent).toBe('-5')
+  })
+
+  // Знак снимается до выбора формы записи, поэтому правило, отсчитанное
+  // от знака, переписывается на равносильное беззнаковое.
+  it('-0.0999 -> {"0.100"} по floor. Порог 0.1 достигнут, остаться в десятичной записи', () => {
+    const result = FormattingUtility.toStandardFormObject(-0.0999, {
+      roundingMode: 'floor',
+    })
+    expect(result.sign).toBe('-')
+    expect(result.mantissa).toBe('0.100')
+    expect(result.base).toBe('')
+    expect(result.exponent).toBe('')
+  })
+
+  it('Когда правило неизвестно, бросить RangeError', () => {
+    expect(() =>
+      FormattingUtility.toStandardFormObject(9.995, {
+        roundingMode: 'halfeven',
+      })
+    ).toThrow(RangeError)
+  })
+})

--- a/tests/FormattingUtility.toStandardFormString.test.js
+++ b/tests/FormattingUtility.toStandardFormString.test.js
@@ -148,3 +148,73 @@ describe('Передаем корректные значения', () => {
     )
   })
 })
+
+describe('Задаём правило округления', () => {
+  it('Когда опции не переданы, округлять по halfExpand', () => {
+    expect(FormattingUtility.toStandardFormString(9.995)).toBe(
+      FormattingUtility.toStandardFormString(9.995, {
+        roundingMode: 'halfExpand',
+      })
+    )
+  })
+
+  it('Когда объект опций пуст, округлять по правилу по умолчанию', () => {
+    expect(FormattingUtility.toStandardFormString(9.995, {})).toBe('10.0')
+  })
+
+  it('9.995 -> "9.99" по trunc. Переноса через разряд не происходит', () => {
+    expect(
+      FormattingUtility.toStandardFormString(9.995, { roundingMode: 'trunc' })
+    ).toBe('9.99')
+  })
+
+  it('2.113 -> "2.12" по ceil. Округление идёт вверх', () => {
+    expect(
+      FormattingUtility.toStandardFormString(2.113, { roundingMode: 'ceil' })
+    ).toBe('2.12')
+  })
+
+  // Знак снимается до выбора формы записи, поэтому правило, отсчитанное
+  // от знака, переписывается на равносильное беззнаковое. Проверки ниже ловят
+  // подмену знака величиной: по величине -2.113 и 2.113 неразличимы,
+  // а floor обязан развести их в разные стороны.
+  it('-2.113 -> "-2.12" по floor. Направление отсчитывается от знака', () => {
+    expect(
+      FormattingUtility.toStandardFormString(-2.113, { roundingMode: 'floor' })
+    ).toBe('-2.12')
+  })
+
+  it('-2.113 -> "-2.11" по trunc. Усечение идёт к нулю независимо от знака', () => {
+    expect(
+      FormattingUtility.toStandardFormString(-2.113, { roundingMode: 'trunc' })
+    ).toBe('-2.11')
+  })
+
+  it('-9.995 -> "-10.0" по floor. Перенос через разряд на отрицательном', () => {
+    expect(
+      FormattingUtility.toStandardFormString(-9.995, { roundingMode: 'floor' })
+    ).toBe('-10.0')
+  })
+
+  // Форму записи выбирает округлённая величина, поэтому правило способно
+  // перевести число из десятичной ветки в экспоненциальную и обратно.
+  it('0.0999 -> "9.99×10^-2" по trunc. Порог 0.1 не достигнут, уйти в стандартный вид', () => {
+    expect(
+      FormattingUtility.toStandardFormString(0.0999, { roundingMode: 'trunc' })
+    ).toBe('9.99×10^-2')
+  })
+
+  it('-0.0999 -> "-0.100" по floor. Порог 0.1 достигнут, остаться в десятичной записи', () => {
+    expect(
+      FormattingUtility.toStandardFormString(-0.0999, { roundingMode: 'floor' })
+    ).toBe('-0.100')
+  })
+
+  it('Когда правило неизвестно, бросить RangeError', () => {
+    expect(() =>
+      FormattingUtility.toStandardFormString(9.995, {
+        roundingMode: 'halfeven',
+      })
+    ).toThrow(RangeError)
+  })
+})


### PR DESCRIPTION
## Что и зачем

После #52 правило округления на середине интервала было зашито в код. Библиотека
не заявляет соответствия какому-либо стандарту округления, поэтому единственного
«правильного» правила у неё нет — и потребителю, которому нужно банковское
округление или усечение, деться было некуда.

Правило вынесено в опцию `roundingMode`, значение по умолчанию сохраняет прежнее
поведение:

```js
toPercentageString(2.25) // "2.3" — как и раньше
toPercentageString(2.25, { roundingMode: 'halfEven' }) // "2.2"
toPercentageString(2.29, { roundingMode: 'trunc' }) // "2.2"
```

Опцию принимают все три публичные функции. Форма — объект настроек, а не
позиционный аргумент: позиционные у функций форматирования не масштабируются
и на месте вызова нечитаемы.

## Округление делегировано Intl.NumberFormat

Ни имена режимов, ни сам алгоритм не изобретались. `roundTo` переписан как
обёртка над `Intl.NumberFormat`, потому что тот решает ровно эту задачу
и решает её точнее прежней реализации:

- **Десятичная семантика закреплена спецификацией.** ECMA-402,
  `ToIntlMathematicalValue`, шаг 4: `Let str be ! Number::toString(x)` — Intl
  округляет кратчайшую десятичную запись числа, а не двоичное приближение.
  Это ровно то, ради чего писались `splitExponential` и `shiftExponent` в #52,
  но обеспечено требованием к любой реализации, а не нашим кодом.
  Для сравнения: `2.675` → Intl `"2.68"`, `toFixed(2)` → `"2.67"`.
- **Попутно закрыт латентный дефект.** На `9007199254740991` при одном знаке
  прежняя реализация теряла единицу (`…990`) из-за строкового round-trip
  через порядок; Intl отдаёт точное значение.
- **Быстрее.** 200 000 вызовов: прежний `roundTo` — 277 мс, новый — 154 мс.
- **Список значений не дублируется.** Допустимые режимы — те же, что у
  `Intl.NumberFormat`; неизвестное значение приводит к `RangeError`
  от самой платформы.

Поддержка `roundingMode`: Chrome 106, Firefox 116, Safari 15.4, Node 19 —
в манифесте уже `"node": ">=22"`.

Вместе с прежним алгоритмом удалена приватная `shiftExponent` и ручное снятие
знака: знак Intl обрабатывает сам. `splitExponential` осталась — её использует
`toExponentialParts`.

## Знак и правила ceil/floor

`standardForm` снимает знак до выбора формы записи, и в отрыве от знака правило,
отсчитанное от знака, означает уже не то: `floor` на отрицательном уводит от
нуля, то есть по величине это `expand`. Без пересчёта `ceil` и `floor` молча
работали бы по величине, совпадая с `expand` и `trunc`.

Поэтому там же, где снимается знак, правило переписывается на равносильное
беззнаковое — по таблице `GetUnsignedRoundingMode` из ECMA-402. Таблица сверена
с фактическим поведением Intl на 360 000 значений и всех серединах интервала:
расхождений нет.

Результат виден на отрицательных:

```js
toStandardFormString(-2.113, { roundingMode: 'floor' }) // "-2.12"
toStandardFormString(-2.113, { roundingMode: 'trunc' }) // "-2.11"
```

## Разделитель и локаль

Локаль `en-US` внутри `roundTo` не настраивается и настраиваться не должна:
`roundTo` возвращает `Number`, строка от Intl — внутренний промежуток, который
разбирается обратно через `Number()`, а тот понимает только ASCII-цифры и точку.
На `ru-RU` разбор даёт `NaN`. Это машинный формат обмена, а не представление.

Вопрос о запятой в выводе остаётся вне этого PR: раздел README «Что библиотека
возвращает, а что нет» фиксирует, что библиотека отдаёт разобранное значение,
а не готовую вёрстку, и локализованный вид собирает потребитель из
`toStandardFormObject()`.

## Проверка

| Проверка | Результат |
| --- | --- |
| `npm run test` | 122 passed (было 98) |
| `npm run lint` | чисто |
| `npm run format:check` | чисто |
| `npm run test:dist` + `publint --strict` | 3 passed, All good |

Отдельно снят эталон вывода `roundTo` до правки и сверен после: **202 000
значений** (все середины интервала в диапазоне ±99.95 плюс детерминированная
выборка по четырём точностям) — **0 расхождений**. Замена движка не сдвинула
дефолтное поведение ни на одном значении.

Существующие прогоны по всем серединам интервала оставлены без изменений: они
и есть защита контракта режима по умолчанию.

Closes #56